### PR TITLE
Bug fixing in screen.cpp

### DIFF
--- a/src/piXPlaneFMCCDU/Screen.cpp
+++ b/src/piXPlaneFMCCDU/Screen.cpp
@@ -455,7 +455,7 @@ void Screen::doDrawLine(SDL_Event * event) {
 		// ' ' blanks the cell, depending on spaceErases
 		else if (c == ' ') {
 			if (spaceErases) {
-				SDL_Rect spaceRect = { baseX, baseY, cellWidth, tallCellHeight };
+				SDL_Rect spaceRect = { baseX, baseY, cellWidth, cellHeight };
 				SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
 				SDL_RenderFillRect(renderer, &spaceRect);
 			};


### PR DESCRIPTION
When the received character is blank, the character should be deleted using the height of the line and not always tallCellHeight as this may clear the top of the characters in the line below (in the case that the line containing the blank is short).